### PR TITLE
Blur peek UX + open tweets in new tab

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "xrai",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "^20.8.9",
+      },
+    },
+  },
+  "packages": {
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.9" } }, "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup.ts"]

--- a/extension/content/hider.js
+++ b/extension/content/hider.js
@@ -30,16 +30,24 @@ var XraiHider = (function () {
       };
       element.addEventListener('click', element._xraiExpandHandler);
     } else if (method === 'blur') {
-      element.style.filter = 'blur(8px)';
-      element.style.transition = 'filter 0.2s ease';
-      element._xraiBlurHandler = function () {
-        if (element.style.filter) {
-          element.style.filter = '';
+      element.style.position = 'relative';
+      // Blur is applied via CSS: article[data-xrai-hidden="blur"] > *:not(.xrai-peek-btn)
+      var btn = document.createElement('button');
+      btn.className = 'xrai-peek-btn';
+      btn.textContent = '\uD83D\uDC41 Show';
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (element.hasAttribute('data-xrai-revealed')) {
+          element.removeAttribute('data-xrai-revealed');
+          btn.textContent = '\uD83D\uDC41 Show';
         } else {
-          element.style.filter = 'blur(8px)';
+          element.setAttribute('data-xrai-revealed', '1');
+          btn.textContent = 'Hide';
         }
-      };
-      element.addEventListener('click', element._xraiBlurHandler);
+      });
+      element.appendChild(btn);
+      element._xraiPeekBtn = btn;
     }
   }
 
@@ -56,14 +64,15 @@ var XraiHider = (function () {
     element.style.cursor = '';
     element.style.filter = '';
     element.style.transition = '';
+    element.removeAttribute('data-xrai-revealed');
 
     if (element._xraiExpandHandler) {
       element.removeEventListener('click', element._xraiExpandHandler);
       delete element._xraiExpandHandler;
     }
-    if (element._xraiBlurHandler) {
-      element.removeEventListener('click', element._xraiBlurHandler);
-      delete element._xraiBlurHandler;
+    if (element._xraiPeekBtn) {
+      element._xraiPeekBtn.remove();
+      delete element._xraiPeekBtn;
     }
   }
 

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -74,6 +74,22 @@ var XraiMain = (function () {
     }, 30000);
   }
 
+  function attachNewTabHandler(el, data) {
+    if (!data.author || !data.id) return;
+    var tweetText = el.querySelector('[data-testid="tweetText"]');
+    if (!tweetText || tweetText._xraiNewTab) return;
+    tweetText._xraiNewTab = true;
+    tweetText.addEventListener('click', function (e) {
+      // Don't intercept if clicking inside interactive elements
+      if (e.target.closest('[data-testid="like"], [data-testid="retweet"], [data-testid="reply"], [data-testid="Tweet-User-Avatar"], [role="group"], video, [data-testid="videoPlayer"], [data-testid="tweetPhoto"]')) return;
+      // Don't open if tweet is blurred and not revealed
+      if (el.getAttribute('data-xrai-hidden') === 'blur' && !el.hasAttribute('data-xrai-revealed')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      window.open('https://x.com/' + data.author + '/status/' + data.id, '_blank');
+    });
+  }
+
   function handleTweet(info) {
     var el = info.element;
     var data = info.data;
@@ -84,6 +100,7 @@ var XraiMain = (function () {
       console.log('[xrai] REPLY hide |', (data.text || '').substring(0, 80));
       XraiHider.hide(el, config.hideMethod);
       XraiIndicator.incrementHidden();
+      attachNewTabHandler(el, data);
       return;
     }
 
@@ -95,6 +112,7 @@ var XraiMain = (function () {
       XraiClassifier.cachePrefilter(data.id, 'noise', pfResult.confidence, pfResult.reason);
       XraiMemory.logClassification(data.text, data.mediaType, 'noise', pfResult.confidence, 'prefilter:' + pfResult.reason);
       XraiIndicator.incrementHidden();
+      attachNewTabHandler(el, data);
       return;
     }
 
@@ -104,6 +122,7 @@ var XraiMain = (function () {
       XraiMemory.logClassification(data.text, data.mediaType, 'signal', 0.5, 'default');
       XraiIndicator.incrementShown();
       XraiReply.attachReplyButton(el, data);
+      attachNewTabHandler(el, data);
       return;
     }
 
@@ -118,6 +137,7 @@ var XraiMain = (function () {
         XraiIndicator.incrementShown();
         XraiReply.attachReplyButton(el, data);
       }
+      attachNewTabHandler(el, data);
     });
   }
 

--- a/extension/content/styles.css
+++ b/extension/content/styles.css
@@ -226,6 +226,41 @@ article:hover .xrai-reply-btn {
 }
 .xrai-reply-copy:hover { background: rgba(255, 255, 255, 0.2); }
 
+/* Peek button on blurred tweets */
+.xrai-peek-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  background: rgba(15, 15, 20, 0.85);
+  color: #ccc;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, color 0.15s;
+}
+.xrai-peek-btn:hover {
+  background: rgba(30, 30, 40, 0.95);
+  color: #fff;
+}
+
+/* Blur children of hidden tweets, but not the peek button */
+article[data-xrai-hidden="blur"] {
+  position: relative;
+}
+article[data-xrai-hidden="blur"] > *:not(.xrai-peek-btn) {
+  filter: blur(8px);
+  transition: filter 0.2s ease;
+}
+article[data-xrai-revealed] > *:not(.xrai-peek-btn) {
+  filter: none;
+}
+
 /* Fade-in animation */
 @keyframes xrai-fade-in {
   from { opacity: 0; transform: translateY(4px); }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "xrai",
+  "private": true,
+  "scripts": {
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@happy-dom/global-registrator": "^20.8.9"
+  }
+}

--- a/tests/detector.test.js
+++ b/tests/detector.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Load detector source
+const detectorSrc = readFileSync(join(import.meta.dir, '../extension/content/detector.js'), 'utf8');
+
+// We need to extract the pure functions. The IIFE only exposes onTweet/start/stop,
+// but we can eval a modified version that also exposes internal helpers for testing.
+function loadDetectorInternals() {
+  // Patch the IIFE to expose internals
+  const patched = detectorSrc
+    .replace(
+      'return {\n    onTweet: onTweet,\n    start: start,\n    stop: stop\n  };',
+      'return {\n    onTweet: onTweet,\n    start: start,\n    stop: stop,\n    _extractTweetId: extractTweetId,\n    _extractAuthor: extractAuthor,\n    _extractData: extractData\n  };'
+    )
+    .replace(/var XraiDetector\s*=\s*/, '');
+  return eval(patched);
+}
+
+function createTweetArticle(author, tweetId) {
+  const article = document.createElement('article');
+  article.setAttribute('data-testid', 'tweet');
+
+  // Author link
+  const authorLink = document.createElement('a');
+  authorLink.setAttribute('href', '/' + author);
+  article.appendChild(authorLink);
+
+  // Status link (with time element)
+  const statusLink = document.createElement('a');
+  statusLink.setAttribute('href', '/' + author + '/status/' + tweetId);
+  statusLink.href = 'https://x.com/' + author + '/status/' + tweetId;
+  const timeEl = document.createElement('time');
+  timeEl.textContent = '2h';
+  statusLink.appendChild(timeEl);
+  article.appendChild(statusLink);
+
+  // Tweet text
+  const textDiv = document.createElement('div');
+  textDiv.setAttribute('data-testid', 'tweetText');
+  textDiv.textContent = 'This is a test tweet';
+  article.appendChild(textDiv);
+
+  return article;
+}
+
+describe('XraiDetector internals', () => {
+  let detector;
+
+  detector = loadDetectorInternals();
+
+  describe('extractTweetId', () => {
+    it('extracts tweet ID from status link', () => {
+      const article = createTweetArticle('testuser', '1234567890');
+      const id = detector._extractTweetId(article);
+      expect(id).toBe('1234567890');
+    });
+
+    it('returns null for tweets without status links', () => {
+      const article = document.createElement('article');
+      article.innerHTML = '<div>No links here</div>';
+      const id = detector._extractTweetId(article);
+      expect(id).toBeNull();
+    });
+
+    it('extracts ID from time element parent link as fallback', () => {
+      const article = document.createElement('article');
+      const link = document.createElement('a');
+      link.href = 'https://x.com/user/status/9876543210';
+      const time = document.createElement('time');
+      time.textContent = '3h';
+      link.appendChild(time);
+      article.appendChild(link);
+      const id = detector._extractTweetId(article);
+      expect(id).toBe('9876543210');
+    });
+  });
+
+  describe('extractAuthor', () => {
+    it('extracts author handle from profile link', () => {
+      const article = createTweetArticle('swyx', '123');
+      const author = detector._extractAuthor(article);
+      expect(author).toBe('swyx');
+    });
+
+    it('returns null when no profile links exist', () => {
+      const article = document.createElement('article');
+      const link = document.createElement('a');
+      link.setAttribute('href', 'https://external.com');
+      article.appendChild(link);
+      const author = detector._extractAuthor(article);
+      expect(author).toBeNull();
+    });
+  });
+
+  describe('permalink construction', () => {
+    it('can construct a valid permalink from extracted data', () => {
+      const article = createTweetArticle('elonmusk', '1799999999999');
+      const data = detector._extractData(article);
+      expect(data).not.toBeNull();
+      const permalink = 'https://x.com/' + data.author + '/status/' + data.id;
+      expect(permalink).toBe('https://x.com/elonmusk/status/1799999999999');
+    });
+
+    it('extractData returns null for tweets without IDs', () => {
+      const article = document.createElement('article');
+      article.innerHTML = '<div>No tweet data</div>';
+      const data = detector._extractData(article);
+      expect(data).toBeNull();
+    });
+  });
+});

--- a/tests/hider.test.js
+++ b/tests/hider.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Load the IIFE source and eval in a context with a mock document
+const hiderSrc = readFileSync(join(import.meta.dir, '../extension/content/hider.js'), 'utf8');
+
+function createMockElement() {
+  const el = document.createElement('article');
+  // Add some child content
+  const child1 = document.createElement('div');
+  child1.textContent = 'Tweet content';
+  el.appendChild(child1);
+  return el;
+}
+
+function loadHider() {
+  // Strip the var assignment so eval returns the IIFE result
+  const stripped = hiderSrc.replace(/var XraiHider\s*=\s*/, '');
+  return eval(stripped);
+}
+
+describe('XraiHider', () => {
+  let XraiHider;
+
+  beforeEach(() => {
+    XraiHider = loadHider();
+  });
+
+  describe('hide() with blur method', () => {
+    it('creates a peek button overlay', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      expect(el.getAttribute('data-xrai-hidden')).toBe('blur');
+      const btn = el.querySelector('.xrai-peek-btn');
+      expect(btn).not.toBeNull();
+      expect(btn.textContent).toBe('👁 Show');
+    });
+
+    it('does not set _xraiBlurHandler on the element', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      expect(el._xraiBlurHandler).toBeUndefined();
+    });
+
+    it('sets position relative on element for button positioning', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      expect(el.style.position).toBe('relative');
+    });
+  });
+
+  describe('peek button toggle', () => {
+    it('clicking button reveals tweet (sets data-xrai-revealed)', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      const btn = el.querySelector('.xrai-peek-btn');
+      btn.click();
+
+      expect(el.hasAttribute('data-xrai-revealed')).toBe(true);
+      expect(btn.textContent).toBe('Hide');
+    });
+
+    it('clicking button again re-hides tweet', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      const btn = el.querySelector('.xrai-peek-btn');
+      btn.click(); // reveal
+      btn.click(); // hide again
+
+      expect(el.hasAttribute('data-xrai-revealed')).toBe(false);
+      expect(btn.textContent).toBe('👁 Show');
+    });
+
+    it('rapid toggling does not break state', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      const btn = el.querySelector('.xrai-peek-btn');
+      for (let i = 0; i < 20; i++) {
+        btn.click();
+      }
+      // 20 clicks = even number = back to hidden
+      expect(el.hasAttribute('data-xrai-revealed')).toBe(false);
+      expect(btn.textContent).toBe('👁 Show');
+    });
+  });
+
+  describe('clicking element does NOT toggle blur', () => {
+    it('clicking the article element itself does not change state', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      // Clicking the element should not toggle anything
+      el.click();
+
+      expect(el.hasAttribute('data-xrai-revealed')).toBe(false);
+      expect(el.querySelector('.xrai-peek-btn').textContent).toBe('👁 Show');
+    });
+  });
+
+  describe('show()', () => {
+    it('removes peek button and blur attributes', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+
+      // Reveal first
+      el.querySelector('.xrai-peek-btn').click();
+
+      XraiHider.show(el);
+
+      expect(el.querySelector('.xrai-peek-btn')).toBeNull();
+      expect(el.hasAttribute('data-xrai-hidden')).toBe(false);
+      expect(el.hasAttribute('data-xrai-revealed')).toBe(false);
+      expect(el._xraiPeekBtn).toBeUndefined();
+    });
+  });
+
+  describe('other hide methods still work', () => {
+    it('remove method sets display none', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'remove');
+
+      expect(el.style.display).toBe('none');
+      expect(el.querySelector('.xrai-peek-btn')).toBeNull();
+    });
+
+    it('collapse method sets height and adds click handler', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'collapse');
+
+      expect(el.style.height).toBe('4px');
+      expect(el._xraiExpandHandler).toBeDefined();
+      expect(el.querySelector('.xrai-peek-btn')).toBeNull();
+    });
+  });
+
+  describe('skip already hidden', () => {
+    it('does not double-hide an element', () => {
+      const el = createMockElement();
+      XraiHider.hide(el, 'blur');
+      XraiHider.hide(el, 'blur'); // second call
+
+      const buttons = el.querySelectorAll('.xrai-peek-btn');
+      expect(buttons.length).toBe(1);
+    });
+  });
+});

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+describe('attachNewTabHandler', () => {
+  // We test the new-tab handler logic directly by simulating what main.js does
+  let openedUrls;
+  let originalOpen;
+
+  beforeEach(() => {
+    openedUrls = [];
+    originalOpen = window.open;
+    window.open = mock((url, target) => {
+      openedUrls.push({ url, target });
+    });
+  });
+
+  function createTweetElement(author, tweetId, opts = {}) {
+    const article = document.createElement('article');
+
+    const textDiv = document.createElement('div');
+    textDiv.setAttribute('data-testid', 'tweetText');
+    textDiv.textContent = 'Some tweet text here';
+    article.appendChild(textDiv);
+
+    if (opts.blurred) {
+      article.setAttribute('data-xrai-hidden', 'blur');
+    }
+    if (opts.revealed) {
+      article.setAttribute('data-xrai-revealed', '1');
+    }
+
+    return { article, textDiv };
+  }
+
+  // Replicate the attachNewTabHandler logic from main.js
+  function attachNewTabHandler(el, data) {
+    if (!data.author || !data.id) return;
+    var tweetText = el.querySelector('[data-testid="tweetText"]');
+    if (!tweetText || tweetText._xraiNewTab) return;
+    tweetText._xraiNewTab = true;
+    tweetText.addEventListener('click', function (e) {
+      if (e.target.closest('[data-testid="like"], [data-testid="retweet"], [data-testid="reply"], [data-testid="Tweet-User-Avatar"], [role="group"], video, [data-testid="videoPlayer"], [data-testid="tweetPhoto"]')) return;
+      if (el.getAttribute('data-xrai-hidden') === 'blur' && !el.hasAttribute('data-xrai-revealed')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      window.open('https://x.com/' + data.author + '/status/' + data.id, '_blank');
+    });
+  }
+
+  it('opens tweet permalink in new tab on text click', () => {
+    const { article, textDiv } = createTweetElement('swyx', '123456');
+    attachNewTabHandler(article, { author: 'swyx', id: '123456' });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(1);
+    expect(openedUrls[0].url).toBe('https://x.com/swyx/status/123456');
+    expect(openedUrls[0].target).toBe('_blank');
+  });
+
+  it('does not open for tweets with no author', () => {
+    const { article, textDiv } = createTweetElement(null, '123');
+    attachNewTabHandler(article, { author: null, id: '123' });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(0);
+  });
+
+  it('does not open for tweets with no id', () => {
+    const { article, textDiv } = createTweetElement('swyx', null);
+    attachNewTabHandler(article, { author: 'swyx', id: null });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(0);
+  });
+
+  it('does not open for blurred (unrevealed) tweets', () => {
+    const { article, textDiv } = createTweetElement('swyx', '123', { blurred: true });
+    attachNewTabHandler(article, { author: 'swyx', id: '123' });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(0);
+  });
+
+  it('opens for revealed (unblurred) noise tweets', () => {
+    const { article, textDiv } = createTweetElement('swyx', '123', { blurred: true, revealed: true });
+    attachNewTabHandler(article, { author: 'swyx', id: '123' });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(1);
+    expect(openedUrls[0].url).toBe('https://x.com/swyx/status/123');
+  });
+
+  it('does not intercept clicks on like button', () => {
+    const { article, textDiv } = createTweetElement('swyx', '123');
+    attachNewTabHandler(article, { author: 'swyx', id: '123' });
+
+    // Simulate a like button inside tweet text (edge case)
+    const likeBtn = document.createElement('div');
+    likeBtn.setAttribute('data-testid', 'like');
+    textDiv.appendChild(likeBtn);
+
+    // Create a click event that originates from the like button
+    const event = new MouseEvent('click', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: likeBtn });
+    textDiv.dispatchEvent(event);
+
+    expect(openedUrls.length).toBe(0);
+  });
+
+  it('does not attach handler twice', () => {
+    const { article, textDiv } = createTweetElement('swyx', '123');
+    attachNewTabHandler(article, { author: 'swyx', id: '123' });
+    attachNewTabHandler(article, { author: 'swyx', id: '123' });
+    textDiv.click();
+
+    expect(openedUrls.length).toBe(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,2 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+GlobalRegistrator.register();


### PR DESCRIPTION
Closes #1

## Summary
Blur mode has no visual affordance — clicking anywhere toggles blur, conflicting with tweet interaction. Additionally, clicking any tweet navigates away from the current tab, destroying filter state, scroll position, and classification counts. Users lose all filtering progress when they want to read a tweet.

## Changes
- `bun.lock`
- `bunfig.toml`
- `extension/content/hider.js`
- `extension/content/main.js`
- `extension/content/styles.css`
- `package.json`
- `tests/detector.test.js`
- `tests/hider.test.js`
- `tests/main.test.js`
- `tests/setup.ts`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification