### PR TITLE
Readable console logs + blur overlay explaining classification reason

### DIFF
--- a/extension/background/worker.js
+++ b/extension/background/worker.js
@@ -3,7 +3,7 @@
 var DEFAULT_URL = 'http://localhost:11434';
 var DEFAULT_MODEL = 'phi4-mini';
 
-var CLASSIFY_SYSTEM = 'You classify tweets as signal or noise. Output ONLY valid JSON.\nScore 4 dimensions (0 or 1 each):\n- NOVELTY: New info (1) or recycled take (0)?\n- SPECIFICITY: Concrete details (1) or vague claims (0)?\n- DENSITY: High insight per word (1) or filler (0)?\n- AUTHENTICITY: Genuine sharing (1) or engagement farming (0)?\n\nNOISE indicators: ALL CAPS text, vague hype (\"insane\", \"wild\", \"crazy\"), video+short text, no concrete details, crypto pumps.\nSIGNAL indicators: specific numbers/tools/results, personal experience with details, technical content.\n\nScore 3-4 = signal (confidence 0.75-0.95). Score 0-2 = noise (confidence 0.75-0.95). Score 2 with some specifics = noise confidence 0.6.\nOutput: {"prediction":"signal"|"noise","confidence":0.6-0.95}';
+var CLASSIFY_SYSTEM = 'You classify tweets as signal or noise. Output ONLY valid JSON.\nScore 4 dimensions (0 or 1 each):\n- NOVELTY: New info (1) or recycled take (0)?\n- SPECIFICITY: Concrete details (1) or vague claims (0)?\n- DENSITY: High insight per word (1) or filler (0)?\n- AUTHENTICITY: Genuine sharing (1) or engagement farming (0)?\n\nNOISE indicators: ALL CAPS text, vague hype (\"insane\", \"wild\", \"crazy\"), video+short text, no concrete details, crypto pumps.\nSIGNAL indicators: specific numbers/tools/results, personal experience with details, technical content.\n\nScore 3-4 = signal (confidence 0.75-0.95). Score 0-2 = noise (confidence 0.75-0.95). Score 2 with some specifics = noise confidence 0.6.\nOutput: {"prediction":"signal"|"noise","confidence":0.6-0.95,"reason":"1-5 word summary"}';
 
 var REPLY_SYSTEM = 'Generate short reply options for a tweet. Output ONLY valid JSON array.\nRules: 5-15 words each, max 80 chars, no hashtags, match energy.\nOutput: [{"style":"curious","text":"..."},{"style":"insight","text":"..."},{"style":"connect","text":"..."}]';
 
@@ -198,10 +198,14 @@ function parseClassification(content) {
     var match = content.match(/\{[\s\S]*?\}/);
     if (match) {
       var obj = JSON.parse(match[0]);
-      return {
+      var result = {
         prediction: obj.prediction === 'signal' ? 'signal' : 'noise',
         confidence: Math.min(1, Math.max(0, parseFloat(obj.confidence) || 0.5))
       };
+      if (obj.reason && typeof obj.reason === 'string') {
+        result.reason = obj.reason.substring(0, 50);
+      }
+      return result;
     }
   } catch (e) { /* fallback */ }
   if (/signal/i.test(content)) return { prediction: 'signal', confidence: 0.6 };

--- a/extension/content/classifier.js
+++ b/extension/content/classifier.js
@@ -29,17 +29,17 @@ var XraiClassifier = (function () {
     return callTimestamps.length >= MAX_CALLS_PER_MINUTE;
   }
 
-  function classify(id, text, mediaType, cb) {
+  function classify(id, text, mediaType, author, cb) {
     // Check cache first
     var cached = checkCache(id);
     if (cached) {
-      console.log('[xrai] CACHE hit:', cached.prediction, '(' + cached.confidence + ')', '|', (text || '').substring(0, 80));
+      console.log('[xrai] CACHE  | @' + (author || '?') + ' | id:' + id + ' | ' + cached.prediction + ' (' + cached.confidence + ') | ' + cached.source + ' | ' + (text || '').substring(0, 60));
       if (cb) cb(cached);
       return;
     }
 
     // Queue for Ollama
-    queue.push({ id: id, text: text, mediaType: mediaType, cb: cb });
+    queue.push({ id: id, text: text, mediaType: mediaType, author: author, cb: cb });
     drain();
   }
 
@@ -72,7 +72,7 @@ var XraiClassifier = (function () {
         if (chrome.runtime.lastError || !response) {
           var fallback = { prediction: 'noise', confidence: 0.5, source: 'error' };
           cacheResult(item.id, fallback);
-          console.log('[xrai] OLLAMA error, fallback noise |', (item.text || '').substring(0, 80));
+          console.log('[xrai] OLLAMA | @' + (item.author || '?') + ' | id:' + item.id + ' | ERROR fallback noise | ' + (item.text || '').substring(0, 60));
           if (item.cb) item.cb(fallback);
         } else {
           var result = {
@@ -80,8 +80,10 @@ var XraiClassifier = (function () {
             confidence: response.confidence || 0.5,
             source: 'model'
           };
+          if (response.reason) result.reason = response.reason;
           cacheResult(item.id, result);
-          console.log('[xrai] OLLAMA \u2192', result.prediction, '(' + result.confidence + ')', '|', (item.text || '').substring(0, 80));
+          var reasonTag = result.reason ? ' | ' + result.reason : '';
+          console.log('[xrai] OLLAMA | @' + (item.author || '?') + ' | id:' + item.id + ' | ' + result.prediction + ' (' + result.confidence + ')' + reasonTag + ' | ' + (item.text || '').substring(0, 60));
           if (item.cb) item.cb(result);
         }
 

--- a/extension/content/hider.js
+++ b/extension/content/hider.js
@@ -14,7 +14,7 @@ var XraiHider = (function () {
     element.style.position = '';
   }
 
-  function hide(element, method) {
+  function hide(element, method, reason) {
     if (!element || element.getAttribute('data-xrai-hidden')) return;
     // Clear pending blur state when transitioning to confirmed hide
     element.removeAttribute('data-xrai-pending');
@@ -62,6 +62,15 @@ var XraiHider = (function () {
       });
       element.appendChild(btn);
       element._xraiPeekBtn = btn;
+
+      // Add reason overlay label
+      if (reason) {
+        var label = document.createElement('div');
+        label.className = 'xrai-blur-label';
+        label.textContent = reason;
+        element.appendChild(label);
+        element._xraiBlurLabel = label;
+      }
     }
   }
 
@@ -87,6 +96,10 @@ var XraiHider = (function () {
     if (element._xraiPeekBtn) {
       element._xraiPeekBtn.remove();
       delete element._xraiPeekBtn;
+    }
+    if (element._xraiBlurLabel) {
+      element._xraiBlurLabel.remove();
+      delete element._xraiBlurLabel;
     }
   }
 

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -98,8 +98,8 @@ var XraiMain = (function () {
 
     // Step 1: Reply filter — blur stays (was applied or apply now)
     if (config && config.contentFilter === 'posts-only' && data.isReply) {
-      console.log('[xrai] REPLY hide |', (data.text || '').substring(0, 80));
-      XraiHider.hide(el, config.hideMethod);
+      console.log('[xrai] REPLY  | @' + (data.author || '?') + ' | id:' + data.id + ' | reply filtered | ' + (data.text || '').substring(0, 60));
+      XraiHider.hide(el, config.hideMethod, 'reply filtered');
       XraiIndicator.incrementHidden();
       attachNewTabHandler(el, data);
       return;
@@ -108,8 +108,8 @@ var XraiMain = (function () {
     // Step 2: Pre-filter (regex) — blur stays, apply confirmed hide
     var pfResult = XraiPrefilter.prefilter(data);
     if (pfResult) {
-      console.log('[xrai] PREFILTER kill:', pfResult.reason, '|', data.text || '');
-      XraiHider.hide(el, config ? config.hideMethod : 'remove');
+      console.log('[xrai] PREFLT | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + pfResult.reason + ' | ' + (data.text || '').substring(0, 60));
+      XraiHider.hide(el, config ? config.hideMethod : 'remove', 'prefilter: ' + pfResult.reason);
       XraiClassifier.cachePrefilter(data.id, 'noise', pfResult.confidence, pfResult.reason);
       XraiMemory.logClassification(data.text, data.mediaType, 'noise', pfResult.confidence, 'prefilter:' + pfResult.reason);
       XraiIndicator.incrementHidden();
@@ -119,7 +119,7 @@ var XraiMain = (function () {
 
     // Step 3: If Ollama unavailable, show by default (no blur)
     if (!ollamaAvailable) {
-      console.log('[xrai] OLLAMA OFF \u2014 showing by default:', (data.text || '').substring(0, 80));
+      console.log('[xrai] OFF    | @' + (data.author || '?') + ' | id:' + data.id + ' | showing by default | ' + (data.text || '').substring(0, 60));
       XraiMemory.logClassification(data.text, data.mediaType, 'signal', 0.5, 'default');
       XraiIndicator.incrementShown();
       XraiReply.attachReplyButton(el, data);
@@ -131,7 +131,12 @@ var XraiMain = (function () {
     var cached = XraiClassifier.checkCache(data.id);
     if (cached) {
       if (cached.prediction === 'noise' && cached.confidence >= threshold) {
-        XraiHider.hide(el, config ? config.hideMethod : 'remove');
+        var cachedReason = cached.reason
+          ? 'AI: ' + cached.reason
+          : cached.source && cached.source.indexOf('prefilter:') === 0
+            ? 'prefilter: ' + cached.source.substring(10)
+            : 'AI: noise (' + cached.confidence + ')';
+        XraiHider.hide(el, config ? config.hideMethod : 'remove', cachedReason);
         XraiIndicator.incrementHidden();
       } else {
         XraiIndicator.incrementShown();
@@ -145,10 +150,13 @@ var XraiMain = (function () {
     XraiHider.blurPending(el);
 
     // Step 6: Classify (Ollama queue)
-    XraiClassifier.classify(data.id, data.text, data.mediaType, function (result) {
+    XraiClassifier.classify(data.id, data.text, data.mediaType, data.author, function (result) {
       if (result.prediction === 'noise' && result.confidence >= threshold) {
+        var reasonLabel = result.reason
+          ? 'AI: ' + result.reason
+          : 'AI: noise (' + result.confidence + ')';
         XraiHider.unblurPending(el);
-        XraiHider.hide(el, config ? config.hideMethod : 'remove');
+        XraiHider.hide(el, config ? config.hideMethod : 'remove', reasonLabel);
         XraiMemory.logClassification(data.text, data.mediaType, 'noise', result.confidence, result.source || 'model');
         XraiIndicator.incrementHidden();
       } else {

--- a/extension/content/styles.css
+++ b/extension/content/styles.css
@@ -258,16 +258,38 @@ article[data-xrai-pending] > * {
   transition: filter 0.2s ease;
 }
 
-/* Blur children of hidden tweets, but not the peek button */
+/* Blur children of hidden tweets, but not the peek button or blur label */
 article[data-xrai-hidden="blur"] {
   position: relative;
 }
-article[data-xrai-hidden="blur"] > *:not(.xrai-peek-btn) {
+article[data-xrai-hidden="blur"] > *:not(.xrai-peek-btn):not(.xrai-blur-label) {
   filter: blur(8px);
   transition: filter 0.2s ease;
 }
-article[data-xrai-revealed] > *:not(.xrai-peek-btn) {
+article[data-xrai-revealed] > *:not(.xrai-peek-btn):not(.xrai-blur-label) {
   filter: none;
+}
+
+/* Blur overlay label — shows classification reason */
+.xrai-blur-label {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 10;
+  background: rgba(15, 15, 20, 0.85);
+  color: #ccc;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  user-select: none;
+  pointer-events: none;
+  max-width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Fade-in animation */


### PR DESCRIPTION
Closes #7

## Summary
Console logs from the classifier are a wall of indistinguishable lines mixing with other extension warnings, making it hard to tie a log entry to a specific tweet. Additionally, blurred tweets give no indication of WHY they were hidden — users can't tell if it was a regex prefilter reject or an Ollama AI decision, reducing trust and debuggability.

## Changes
- `extension/background/worker.js`
- `extension/content/classifier.js`
- `extension/content/hider.js`
- `extension/content/main.js`
- `extension/content/styles.css`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification