### PR TITLE
Center show/hide button and add signal overlay label

### DIFF
--- a/extension/content/hider.js
+++ b/extension/content/hider.js
@@ -103,10 +103,21 @@ var XraiHider = (function () {
     }
   }
 
+  function addSignalLabel(element, reason) {
+    if (!element || !reason || element._xraiSignalLabel) return;
+    element.style.position = 'relative';
+    var label = document.createElement('div');
+    label.className = 'xrai-signal-label';
+    label.textContent = reason;
+    element.appendChild(label);
+    element._xraiSignalLabel = label;
+  }
+
   return {
     blurPending: blurPending,
     unblurPending: unblurPending,
     hide: hide,
-    show: show
+    show: show,
+    addSignalLabel: addSignalLabel
   };
 })();

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -139,6 +139,10 @@ var XraiMain = (function () {
         XraiHider.hide(el, config ? config.hideMethod : 'remove', cachedReason);
         XraiIndicator.incrementHidden();
       } else {
+        var cachedSignalReason = cached.reason
+          ? 'AI: ' + cached.reason
+          : 'AI: signal (' + cached.confidence + ')';
+        XraiHider.addSignalLabel(el, cachedSignalReason);
         XraiIndicator.incrementShown();
         XraiReply.attachReplyButton(el, data);
       }
@@ -161,6 +165,10 @@ var XraiMain = (function () {
         XraiIndicator.incrementHidden();
       } else {
         XraiHider.unblurPending(el);
+        var signalLabel = result.reason
+          ? 'AI: ' + result.reason
+          : 'AI: signal (' + result.confidence + ')';
+        XraiHider.addSignalLabel(el, signalLabel);
         XraiMemory.logClassification(data.text, data.mediaType, 'signal', result.confidence, result.source || 'model');
         XraiIndicator.incrementShown();
         XraiReply.attachReplyButton(el, data);

--- a/extension/content/styles.css
+++ b/extension/content/styles.css
@@ -230,7 +230,8 @@ article:hover .xrai-reply-btn {
 .xrai-peek-btn {
   position: absolute;
   top: 8px;
-  right: 8px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 10;
   background: rgba(15, 15, 20, 0.85);
   color: #ccc;
@@ -283,6 +284,28 @@ article[data-xrai-revealed] > *:not(.xrai-peek-btn):not(.xrai-blur-label) {
   padding: 3px 10px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  user-select: none;
+  pointer-events: none;
+  max-width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Signal label — shows classification reason on signal tweets */
+.xrai-signal-label {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 10;
+  background: rgba(15, 15, 20, 0.85);
+  color: #4ade80;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(74, 222, 128, 0.2);
   backdrop-filter: blur(8px);
   user-select: none;
   pointer-events: none;


### PR DESCRIPTION
Closes #9

## Summary
The xrai-peek-btn (Show/Hide toggle) is positioned top-right (top:8px, right:8px) which overlaps Twitter/X's native Grok and three-dot menu buttons, making them inaccessible. Additionally, when a tweet is classified as signal, no overlay label is shown explaining why it was considered high-signal — users only see reason labels on noise tweets.

## Changes
- `extension/content/hider.js`
- `extension/content/main.js`
- `extension/content/styles.css`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification