### PR TITLE
Fix stats accumulation and add daily X time tracking

### DIFF
--- a/extension/content/indicator.js
+++ b/extension/content/indicator.js
@@ -157,15 +157,22 @@ var XraiIndicator = (function () {
       });
     });
 
-    // Load stats
-    XraiMemory.getStats().then(function (stats) {
+    // Load stats and daily time
+    Promise.all([XraiMemory.getStats(), XraiMemory.getDailyTime()]).then(function (results) {
+      var stats = results[0];
+      var dailySecs = results[1];
       var statsEl = popup.querySelector('#xrai-s-stats');
       if (!statsEl) return;
       var timeSaved = Math.round(stats.noise * 3); // ~3s per hidden tweet
+      var dailyMin = Math.floor(dailySecs / 60);
+      var dailyLabel = dailyMin < 60
+        ? dailyMin + 'm'
+        : Math.floor(dailyMin / 60) + 'h ' + (dailyMin % 60) + 'm';
       statsEl.textContent = 'Processed: ' + stats.total +
         ' | Signal: ' + stats.signal +
         ' | Noise: ' + stats.noise +
-        ' | ~' + timeSaved + 's saved';
+        ' | ~' + timeSaved + 's saved' +
+        '\nToday on X: ' + dailyLabel;
     });
   }
 

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -127,6 +127,7 @@ var XraiMain = (function () {
     if (config && config.contentFilter === 'posts-only' && data.isReply) {
       console.log('[xrai] REPLY  | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + mediaTag + ' | reply filtered | ' + (enrichedText || '').substring(0, 80));
       XraiHider.hide(el, config.hideMethod, 'reply filtered');
+      XraiMemory.incrementStats('noise');
       XraiIndicator.incrementHidden();
       attachNewTabHandler(el, data);
       return;

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -8,10 +8,11 @@ var XraiMain = (function () {
   function start() {
     console.log('[xrai] Starting...');
 
-    // 1. Init memory (for classification logging)
+    // 1. Init memory (for classification logging) + start time tracking
     XraiMemory.init().catch(function (e) {
       console.warn('[xrai] Memory init error:', e);
     });
+    XraiMemory.startSession();
 
     // 2. Load config
     XraiConfig.getConfig().then(function (cfg) {
@@ -138,6 +139,8 @@ var XraiMain = (function () {
       XraiHider.hide(el, config ? config.hideMethod : 'remove', 'prefilter: ' + pfResult.reason);
       XraiClassifier.cachePrefilter(data.id, 'noise', pfResult.confidence, pfResult.reason);
       XraiMemory.logClassification(data.text, data.mediaType, 'noise', pfResult.confidence, 'prefilter:' + pfResult.reason);
+      XraiMemory.incrementStats('noise');
+      XraiMemory.markSeen(XraiMemory.computeFingerprint(data.text, data.mediaType), 'noise');
       XraiIndicator.incrementHidden();
       attachNewTabHandler(el, data);
       return;
@@ -149,6 +152,8 @@ var XraiMain = (function () {
       console.log('[xrai] MEDIA  | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + mediaTag + ' | media-only, no text to classify');
       XraiClassifier.cachePrefilter(data.id, 'noise', 0.55, 'media-only');
       XraiMemory.logClassification('', data.mediaType, 'noise', 0.55, 'media-only');
+      XraiMemory.incrementStats('noise');
+      XraiMemory.markSeen(XraiMemory.computeFingerprint('', data.mediaType), 'noise');
       // Low confidence — don't aggressively hide, use blur so user can reveal
       XraiHider.hide(el, 'blur', 'media-only: no text to classify');
       XraiIndicator.incrementHidden();
@@ -160,6 +165,8 @@ var XraiMain = (function () {
     if (!ollamaAvailable) {
       console.log('[xrai] OFF    | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + mediaTag + ' | showing by default | ' + (enrichedText || '').substring(0, 80));
       XraiMemory.logClassification(data.text, data.mediaType, 'signal', 0.5, 'default');
+      XraiMemory.incrementStats('signal');
+      XraiMemory.markSeen(XraiMemory.computeFingerprint(data.text, data.mediaType), 'signal');
       XraiIndicator.incrementShown();
       XraiReply.attachReplyButton(el, data);
       attachNewTabHandler(el, data);
@@ -201,6 +208,8 @@ var XraiMain = (function () {
         XraiHider.unblurPending(el);
         XraiHider.hide(el, config ? config.hideMethod : 'remove', reasonLabel);
         XraiMemory.logClassification(data.text, data.mediaType, 'noise', result.confidence, result.source || 'model');
+        XraiMemory.incrementStats('noise');
+        XraiMemory.markSeen(XraiMemory.computeFingerprint(data.text, data.mediaType), 'noise');
         XraiIndicator.incrementHidden();
       } else {
         XraiHider.unblurPending(el);
@@ -209,6 +218,8 @@ var XraiMain = (function () {
           : 'AI: signal (' + result.confidence + ')';
         XraiHider.addSignalLabel(el, signalLabel);
         XraiMemory.logClassification(data.text, data.mediaType, 'signal', result.confidence, result.source || 'model');
+        XraiMemory.incrementStats('signal');
+        XraiMemory.markSeen(XraiMemory.computeFingerprint(data.text, data.mediaType), 'signal');
         XraiIndicator.incrementShown();
         XraiReply.attachReplyButton(el, data);
       }

--- a/extension/lib/memory.js
+++ b/extension/lib/memory.js
@@ -104,9 +104,38 @@ const XraiMemory = (function () {
   }
 
   var STATS_KEY = 'xrai_stats_totals';
+  // In-memory stats accumulator — avoids async read-modify-write races
+  var _memStats = null; // loaded from storage on first increment
+  var _statsFlushTimer = null;
+  var STATS_FLUSH_INTERVAL = 10000; // flush to storage every 10s
+
+  function _ensureStatsLoaded() {
+    return new Promise(function (resolve) {
+      if (_memStats) { resolve(); return; }
+      chrome.storage.local.get(STATS_KEY, function (result) {
+        if (!_memStats) {
+          _memStats = result[STATS_KEY] || { total: 0, signal: 0, noise: 0 };
+        }
+        resolve();
+      });
+    });
+  }
+
+  function _flushStats() {
+    if (!_memStats) return;
+    var obj = {};
+    obj[STATS_KEY] = { total: _memStats.total, signal: _memStats.signal, noise: _memStats.noise };
+    chrome.storage.local.set(obj);
+  }
+
+  function _startStatsFlush() {
+    if (_statsFlushTimer) return;
+    _statsFlushTimer = setInterval(_flushStats, STATS_FLUSH_INTERVAL);
+  }
 
   function getStats() {
     return new Promise(function (resolve) {
+      if (_memStats) { resolve({ total: _memStats.total, signal: _memStats.signal, noise: _memStats.noise }); return; }
       chrome.storage.local.get(STATS_KEY, function (result) {
         var stats = result[STATS_KEY] || { total: 0, signal: 0, noise: 0 };
         resolve(stats);
@@ -115,64 +144,99 @@ const XraiMemory = (function () {
   }
 
   function incrementStats(prediction) {
-    return new Promise(function (resolve) {
-      chrome.storage.local.get(STATS_KEY, function (result) {
-        var stats = result[STATS_KEY] || { total: 0, signal: 0, noise: 0 };
-        stats.total++;
-        if (prediction === 'signal') stats.signal++;
-        else if (prediction === 'noise') stats.noise++;
-        var obj = {};
-        obj[STATS_KEY] = stats;
-        chrome.storage.local.set(obj, function () { resolve(stats); });
-      });
+    return _ensureStatsLoaded().then(function () {
+      _memStats.total++;
+      if (prediction === 'signal') _memStats.signal++;
+      else if (prediction === 'noise') _memStats.noise++;
+      _startStatsFlush();
+      return { total: _memStats.total, signal: _memStats.signal, noise: _memStats.noise };
     });
   }
 
   // === Daily time tracking ===
   var DAILY_TIME_KEY = 'xrai_daily_time';
   var _timeInterval = null;
+  // In-memory time accumulator — avoids async read-modify-write races
+  var _memTime = null; // { date, seconds }
+  var _lastTickTime = 0;
 
   function _todayStr() {
     var d = new Date();
     return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
   }
 
-  function startSession() {
-    var now = Date.now();
-    // Save time every 30s while page is visible
-    _timeInterval = setInterval(function () {
-      if (!document.hidden) {
-        _saveTimeIncrement(30);
-      }
-    }, 30000);
+  function _ensureTimeLoaded() {
+    return new Promise(function (resolve) {
+      if (_memTime) { resolve(); return; }
+      chrome.storage.local.get(DAILY_TIME_KEY, function (result) {
+        if (!_memTime) {
+          var data = result[DAILY_TIME_KEY] || {};
+          var today = _todayStr();
+          if (data.date === today) {
+            _memTime = { date: today, seconds: data.seconds || 0 };
+          } else {
+            _memTime = { date: today, seconds: 0 };
+          }
+        }
+        resolve();
+      });
+    });
+  }
 
-    // Pause/resume on visibility change
-    document.addEventListener('visibilitychange', function () {
-      // No action needed — the interval simply skips hidden ticks
+  function startSession() {
+    if (_timeInterval) return; // guard against duplicate calls
+    _lastTickTime = Date.now();
+
+    _ensureTimeLoaded().then(function () {
+      // Save time every 30s while page is visible
+      _timeInterval = setInterval(function () {
+        if (!document.hidden) {
+          var now = Date.now();
+          var elapsed = Math.round((now - _lastTickTime) / 1000);
+          _lastTickTime = now;
+          _saveTimeIncrement(elapsed);
+        } else {
+          _lastTickTime = Date.now(); // reset so hidden time isn't counted on resume
+        }
+      }, 30000);
     });
 
-    // Save on page unload
+    // Flush partial interval + stats on page unload
     window.addEventListener('beforeunload', function () {
-      if (_timeInterval) clearInterval(_timeInterval);
+      if (_timeInterval) {
+        clearInterval(_timeInterval);
+        _timeInterval = null;
+      }
+      // Save any accumulated time since last tick
+      if (_lastTickTime && !document.hidden) {
+        var elapsed = Math.round((Date.now() - _lastTickTime) / 1000);
+        if (elapsed > 0) _saveTimeIncrement(elapsed);
+      }
+      _flushStats();
     });
   }
 
   function _saveTimeIncrement(seconds) {
-    chrome.storage.local.get(DAILY_TIME_KEY, function (result) {
-      var data = result[DAILY_TIME_KEY] || {};
-      var today = _todayStr();
-      if (data.date !== today) {
-        // New day — reset
-        data = { date: today, seconds: 0 };
-      }
-      data.seconds += seconds;
-      var obj = {};
-      obj[DAILY_TIME_KEY] = data;
-      chrome.storage.local.set(obj);
-    });
+    if (!_memTime) return;
+    var today = _todayStr();
+    if (_memTime.date !== today) {
+      // New day — reset
+      _memTime = { date: today, seconds: 0 };
+    }
+    _memTime.seconds += seconds;
+    var obj = {};
+    obj[DAILY_TIME_KEY] = { date: _memTime.date, seconds: _memTime.seconds };
+    chrome.storage.local.set(obj);
   }
 
   function getDailyTime() {
+    if (_memTime) {
+      var today = _todayStr();
+      if (_memTime.date === today) {
+        return Promise.resolve(_memTime.seconds);
+      }
+      return Promise.resolve(0);
+    }
     return new Promise(function (resolve) {
       chrome.storage.local.get(DAILY_TIME_KEY, function (result) {
         var data = result[DAILY_TIME_KEY] || {};
@@ -188,6 +252,10 @@ const XraiMemory = (function () {
 
   function clearAll() {
     return new Promise(function (resolve) {
+      // Clear chrome.storage stats and time tracking
+      chrome.storage.local.remove([STATS_KEY, DAILY_TIME_KEY]);
+      _memStats = { total: 0, signal: 0, noise: 0 };
+      _memTime = { date: _todayStr(), seconds: 0 };
       if (!db) { resolve(); return; }
       var tx = db.transaction(STORE_NAME, 'readwrite');
       tx.objectStore(STORE_NAME).clear();

--- a/extension/lib/memory.js
+++ b/extension/lib/memory.js
@@ -103,25 +103,86 @@ const XraiMemory = (function () {
     });
   }
 
+  var STATS_KEY = 'xrai_stats_totals';
+
   function getStats() {
     return new Promise(function (resolve) {
-      if (!db) { resolve({ total: 0, signal: 0, noise: 0 }); return; }
-      var tx = db.transaction(STORE_NAME, 'readonly');
-      var store = tx.objectStore(STORE_NAME);
-      var stats = { total: 0, signal: 0, noise: 0 };
-      var cursor = store.openCursor();
-      cursor.onsuccess = function (e) {
-        var c = e.target.result;
-        if (c) {
-          stats.total++;
-          if (c.value.classification === 'signal') stats.signal++;
-          else if (c.value.classification === 'noise') stats.noise++;
-          c.continue();
+      chrome.storage.local.get(STATS_KEY, function (result) {
+        var stats = result[STATS_KEY] || { total: 0, signal: 0, noise: 0 };
+        resolve(stats);
+      });
+    });
+  }
+
+  function incrementStats(prediction) {
+    return new Promise(function (resolve) {
+      chrome.storage.local.get(STATS_KEY, function (result) {
+        var stats = result[STATS_KEY] || { total: 0, signal: 0, noise: 0 };
+        stats.total++;
+        if (prediction === 'signal') stats.signal++;
+        else if (prediction === 'noise') stats.noise++;
+        var obj = {};
+        obj[STATS_KEY] = stats;
+        chrome.storage.local.set(obj, function () { resolve(stats); });
+      });
+    });
+  }
+
+  // === Daily time tracking ===
+  var DAILY_TIME_KEY = 'xrai_daily_time';
+  var _timeInterval = null;
+
+  function _todayStr() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function startSession() {
+    var now = Date.now();
+    // Save time every 30s while page is visible
+    _timeInterval = setInterval(function () {
+      if (!document.hidden) {
+        _saveTimeIncrement(30);
+      }
+    }, 30000);
+
+    // Pause/resume on visibility change
+    document.addEventListener('visibilitychange', function () {
+      // No action needed — the interval simply skips hidden ticks
+    });
+
+    // Save on page unload
+    window.addEventListener('beforeunload', function () {
+      if (_timeInterval) clearInterval(_timeInterval);
+    });
+  }
+
+  function _saveTimeIncrement(seconds) {
+    chrome.storage.local.get(DAILY_TIME_KEY, function (result) {
+      var data = result[DAILY_TIME_KEY] || {};
+      var today = _todayStr();
+      if (data.date !== today) {
+        // New day — reset
+        data = { date: today, seconds: 0 };
+      }
+      data.seconds += seconds;
+      var obj = {};
+      obj[DAILY_TIME_KEY] = data;
+      chrome.storage.local.set(obj);
+    });
+  }
+
+  function getDailyTime() {
+    return new Promise(function (resolve) {
+      chrome.storage.local.get(DAILY_TIME_KEY, function (result) {
+        var data = result[DAILY_TIME_KEY] || {};
+        var today = _todayStr();
+        if (data.date !== today) {
+          resolve(0);
         } else {
-          resolve(stats);
+          resolve(data.seconds || 0);
         }
-      };
-      cursor.onerror = function () { resolve(stats); };
+      });
     });
   }
 
@@ -264,6 +325,9 @@ const XraiMemory = (function () {
     getCorrections: getCorrections,
     getCorrectionCount: getCorrectionCount,
     clearCorrections: clearCorrections,
-    exportCorrections: exportCorrections
+    exportCorrections: exportCorrections,
+    incrementStats: incrementStats,
+    startSession: startSession,
+    getDailyTime: getDailyTime
   };
 })();


### PR DESCRIPTION
Closes #17

## Summary
Stats (Processed/Signal/Noise) always show 0 because `getStats()` reads from IndexedDB fingerprints store, but `markSeen()` is never called anywhere — classifications only go to `chrome.storage.local` via `logClassification()`. The IndexedDB store stays empty forever. Additionally, the user wants to track daily time spent on X.

## Changes
- `extension/content/indicator.js`
- `extension/content/main.js`
- `extension/lib/memory.js`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification