### PR TITLE
Scope filtering to home feed only; skip status and profile pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ xrai is a Chrome extension that filters Twitter/X feeds using local AI (Ollama).
 **Chrome Extension** (Manifest V3, vanilla JS, no build step):
 - Content scripts inject into x.com, detect tweets via MutationObserver
 - Classification pipeline: reply filter → prefilter (regex) → result cache → Ollama model (5 concurrent)
+- Filtering is scoped to `/home*` (and `/`) only — status detail, profile, explore, notifications, search, bookmarks, lists, and messages render tweets untouched (no blur, hide, or classify). Detection + reply-button + new-tab handlers still attach everywhere.
 - Service worker proxies HTTP calls to Ollama (content scripts can't call localhost in MV3)
 - All state in chrome.storage.local + in-memory result cache (no IndexedDB dedup)
 

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -4,6 +4,12 @@ var XraiMain = (function () {
 
   var config = null;
   var ollamaAvailable = false;
+  var offHomeLogged = Object.create(null);
+
+  function isHomeFeed() {
+    var path = window.location.pathname;
+    return path === '/' || path === '/home' || path.indexOf('/home/') === 0;
+  }
 
   function start() {
     console.log('[xrai] Starting...');
@@ -124,6 +130,18 @@ var XraiMain = (function () {
     }
     if (data.wasQuoteExpanded) {
       console.log('[xrai] EXPAND | @' + (data.author || '?') + ' | id:' + data.id + ' | quoted tweet text was expanded');
+    }
+
+    // Off-home routes (status detail, profile, explore, etc.): user is reading intentionally,
+    // so skip the entire filtering pipeline. Keep reply button + new-tab handlers available.
+    if (!isHomeFeed()) {
+      if (data.id && !offHomeLogged[data.id]) {
+        offHomeLogged[data.id] = true;
+        console.log('[xrai] SKIP   | path=' + window.location.pathname + ' | off-home, no filtering | id:' + data.id);
+      }
+      XraiReply.attachReplyButton(el, data);
+      attachNewTabHandler(el, data);
+      return;
     }
 
     // Step 1: Reply filter — blur stays (was applied or apply now)


### PR DESCRIPTION
Closes #19

## Summary
Today the extension runs the full classify/blur/hide pipeline on every tweet it detects, regardless of which X route is being viewed. When the user clicks into a specific post (`/<user>/status/<id>`) or a user profile (`/<user>`), xrai still blurs and removes tweets — including the main post the user chose to read and its comment thread. This defeats user intent: navigating to a detail page is an explicit signal of interest, so filtering there is harmful rather than helpful. Filtering should only run on the main recommendation feed (home), where the user is being fed algorithmic recommendations they did not ask for.

## Changes
- `CLAUDE.md`
- `extension/content/main.js`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification