### PR TITLE
feat: popup toggle to un-blur all noise tweets

### DIFF
--- a/extension/content/indicator.js
+++ b/extension/content/indicator.js
@@ -107,6 +107,7 @@ var XraiIndicator = (function () {
       '<label>Aggressiveness<input type="range" id="xrai-s-threshold" min="0.5" max="0.9" step="0.05" value="' + cfg.confidenceThreshold + '"><span id="xrai-s-threshold-val">' + cfg.confidenceThreshold + '</span></label>' +
       '<label>Content<select id="xrai-s-filter"><option value="posts-only"' + (cfg.contentFilter === 'posts-only' ? ' selected' : '') + '>Posts only</option><option value="all"' + (cfg.contentFilter === 'all' ? ' selected' : '') + '>All</option></select></label>' +
       '<label>Hide method<select id="xrai-s-hide"><option value="remove"' + (cfg.hideMethod === 'remove' ? ' selected' : '') + '>Remove</option><option value="collapse"' + (cfg.hideMethod === 'collapse' ? ' selected' : '') + '>Collapse</option><option value="blur"' + (cfg.hideMethod === 'blur' ? ' selected' : '') + '>Blur</option></select></label>' +
+      '<label class="xrai-s-toggle"><input type="checkbox" id="xrai-s-bluroff"' + (cfg.blurOff ? ' checked' : '') + '> Show blurred tweets (un-blur all)</label>' +
       '<div class="xrai-settings-actions">' +
       '<button id="xrai-s-save">Save</button>' +
       '<button id="xrai-s-clear">Clear memory</button>' +
@@ -143,7 +144,8 @@ var XraiIndicator = (function () {
         model: popup.querySelector('#xrai-s-model').value,
         confidenceThreshold: parseFloat(slider.value),
         contentFilter: popup.querySelector('#xrai-s-filter').value,
-        hideMethod: popup.querySelector('#xrai-s-hide').value
+        hideMethod: popup.querySelector('#xrai-s-hide').value,
+        blurOff: popup.querySelector('#xrai-s-bluroff').checked
       }).then(function () {
         closePopup();
       });

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -57,6 +57,25 @@ var XraiMain = (function () {
       console.log('[xrai] Running. Filter: ' + cfg.contentFilter + ', Hide: ' + cfg.hideMethod);
     });
 
+    // Reactive config updates (popup save triggers onChanged)
+    if (chrome.storage && chrome.storage.onChanged) {
+      chrome.storage.onChanged.addListener(function (changes, area) {
+        if (area !== 'local' || !changes.xrai_config) return;
+        var newCfg = changes.xrai_config.newValue;
+        if (!newCfg) return;
+        var wasBlurOff = !!(config && config.blurOff);
+        config = newCfg;
+        XraiClassifier.configure(newCfg);
+        if (newCfg.blurOff && !wasBlurOff) {
+          var blurred = document.querySelectorAll('article[data-xrai-hidden="blur"]');
+          for (var i = 0; i < blurred.length; i++) XraiHider.show(blurred[i]);
+          var pending = document.querySelectorAll('article[data-xrai-pending]');
+          for (var j = 0; j < pending.length; j++) XraiHider.unblurPending(pending[j]);
+          console.log('[xrai] blurOff ON — un-blurred ' + blurred.length + ' tweet(s)');
+        }
+      });
+    }
+
     // Periodic health check (every 30s)
     var healthInterval = setInterval(function () {
       if (!chrome.runtime || !chrome.runtime.id) {
@@ -117,6 +136,11 @@ var XraiMain = (function () {
     return parts.join(' ');
   }
 
+  function applyHide(el, method, reason) {
+    if (method === 'blur' && config && config.blurOff) return;
+    XraiHider.hide(el, method, reason);
+  }
+
   function handleTweet(info) {
     var el = info.element;
     var data = info.data;
@@ -147,7 +171,7 @@ var XraiMain = (function () {
     // Step 1: Reply filter — blur stays (was applied or apply now)
     if (config && config.contentFilter === 'posts-only' && data.isReply) {
       console.log('[xrai] REPLY  | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + mediaTag + ' | reply filtered | ' + (enrichedText || '').substring(0, 80));
-      XraiHider.hide(el, config.hideMethod, 'reply filtered');
+      applyHide(el, config.hideMethod, 'reply filtered');
       XraiMemory.incrementStats('noise');
       XraiIndicator.incrementHidden();
       attachNewTabHandler(el, data);
@@ -158,7 +182,7 @@ var XraiMain = (function () {
     var pfResult = XraiPrefilter.prefilter(data);
     if (pfResult) {
       console.log('[xrai] PREFLT | @' + (data.author || '?') + ' | id:' + data.id + ' | ' + mediaTag + ' | ' + pfResult.reason + ' | ' + (enrichedText || '').substring(0, 80));
-      XraiHider.hide(el, config ? config.hideMethod : 'remove', 'prefilter: ' + pfResult.reason);
+      applyHide(el, config ? config.hideMethod : 'remove', 'prefilter: ' + pfResult.reason);
       XraiClassifier.cachePrefilter(data.id, 'noise', pfResult.confidence, pfResult.reason);
       XraiMemory.logClassification(data.text, data.mediaType, 'noise', pfResult.confidence, 'prefilter:' + pfResult.reason);
       XraiMemory.incrementStats('noise');
@@ -177,7 +201,7 @@ var XraiMain = (function () {
       XraiMemory.incrementStats('noise');
       XraiMemory.markSeen(XraiMemory.computeFingerprint('', data.mediaType), 'noise');
       // Low confidence — don't aggressively hide, use blur so user can reveal
-      XraiHider.hide(el, 'blur', 'media-only: no text to classify');
+      applyHide(el, 'blur', 'media-only: no text to classify');
       XraiIndicator.incrementHidden();
       attachNewTabHandler(el, data);
       return;
@@ -204,7 +228,7 @@ var XraiMain = (function () {
           : cached.source && cached.source.indexOf('prefilter:') === 0
             ? 'prefilter: ' + cached.source.substring(10)
             : 'AI: noise (' + cached.confidence + ')';
-        XraiHider.hide(el, config ? config.hideMethod : 'remove', cachedReason);
+        applyHide(el, config ? config.hideMethod : 'remove', cachedReason);
         XraiIndicator.incrementHidden();
       } else {
         var cachedSignalReason = cached.reason
@@ -219,7 +243,7 @@ var XraiMain = (function () {
     }
 
     // Step 5: Blur immediately while waiting for classification
-    XraiHider.blurPending(el);
+    if (!(config && config.blurOff)) XraiHider.blurPending(el);
 
     // Step 6: Classify (Ollama queue) — use enriched text for better context
     XraiClassifier.classify(data.id, enrichedText, data.mediaType, data.author, function (result) {
@@ -228,7 +252,7 @@ var XraiMain = (function () {
           ? 'AI: ' + result.reason
           : 'AI: noise (' + result.confidence + ')';
         XraiHider.unblurPending(el);
-        XraiHider.hide(el, config ? config.hideMethod : 'remove', reasonLabel);
+        applyHide(el, config ? config.hideMethod : 'remove', reasonLabel);
         XraiMemory.logClassification(data.text, data.mediaType, 'noise', result.confidence, result.source || 'model');
         XraiMemory.incrementStats('noise');
         XraiMemory.markSeen(XraiMemory.computeFingerprint(data.text, data.mediaType), 'noise');

--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -8,6 +8,7 @@ var XraiConfig = (function () {
     confidenceThreshold: 0.7,
     contentFilter: 'posts-only',
     hideMethod: 'remove',
+    blurOff: false,
     replyStyle: 'curious',
     memoryRetentionDays: 30,
     maxModelCallsPerMinute: 100,


### PR DESCRIPTION
## Summary

Adds a **Show blurred tweets (un-blur all)** checkbox to the xrai settings popup. Lets you reveal currently-blurred noise tweets without disabling the extension or losing classification data.

## Behavior

- **Toggle ON** → existing `article[data-xrai-hidden="blur"]` tweets are immediately revealed via `XraiHider.show()`; future noise classifications skip the blur step. Classification keeps running in the background (stats continue to accumulate).
- **Toggle OFF** → future noise tweets get blurred again. Already-visible tweets stay visible (no retroactive re-blur — refresh x.com if you want them back).
- **Remove/collapse unaffected** → if `hideMethod` is `remove` or `collapse`, those tweets stay hidden. The toggle only governs the blur path.

## Changes

- `extension/lib/config.js` — new `blurOff: false` default
- `extension/content/indicator.js` — checkbox in settings popup, wired into Save
- `extension/content/main.js`:
  - `applyHide()` helper gates `XraiHider.hide()` when method is `blur` and `blurOff` is true
  - `chrome.storage.onChanged` listener syncs config on popup save and sweeps `article[data-xrai-hidden="blur"]` + `article[data-xrai-pending]` through `XraiHider.show()` / `unblurPending()`
  - Pending-blur flash also gated so noise tweets don't flicker while classifying

## Test plan

- [ ] Reload extension, set `hideMethod` to `blur`, confirm noise tweets are blurred on x.com/home
- [ ] Check "Show blurred tweets" + Save — all blurred tweets become visible instantly
- [ ] Scroll to load new tweets — no blur flash, classification logs still appear in DevTools
- [ ] Uncheck + Save, scroll new tweets — blur returns for new noise
- [ ] Switch `hideMethod` to `remove`, toggle `blurOff` — removed tweets stay hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)