### PR TITLE
fix: UX friction pass — blur debounce, stable pill DOM, larger touch targets

### DIFF
--- a/extension/content/hider.js
+++ b/extension/content/hider.js
@@ -2,14 +2,24 @@
 var XraiHider = (function () {
   'use strict';
 
+  var PENDING_BLUR_DELAY_MS = 300;
+
   function blurPending(element) {
     if (!element) return;
-    element.setAttribute('data-xrai-pending', '1');
-    element.style.position = 'relative';
+    if (element._xraiPendingTimer || element.hasAttribute('data-xrai-pending')) return;
+    element._xraiPendingTimer = setTimeout(function () {
+      element._xraiPendingTimer = null;
+      element.setAttribute('data-xrai-pending', '1');
+      element.style.position = 'relative';
+    }, PENDING_BLUR_DELAY_MS);
   }
 
   function unblurPending(element) {
     if (!element) return;
+    if (element._xraiPendingTimer) {
+      clearTimeout(element._xraiPendingTimer);
+      element._xraiPendingTimer = null;
+    }
     element.removeAttribute('data-xrai-pending');
     element.style.position = '';
   }
@@ -45,7 +55,6 @@ var XraiHider = (function () {
       element.addEventListener('click', element._xraiExpandHandler);
     } else if (method === 'blur') {
       element.style.position = 'relative';
-      // Blur is applied via CSS: article[data-xrai-hidden="blur"] > *:not(.xrai-peek-btn)
       var btn = document.createElement('button');
       btn.className = 'xrai-peek-btn';
       btn.textContent = '\uD83D\uDC41 Show';
@@ -63,7 +72,6 @@ var XraiHider = (function () {
       element.appendChild(btn);
       element._xraiPeekBtn = btn;
 
-      // Add reason overlay label
       if (reason) {
         var label = document.createElement('div');
         label.className = 'xrai-blur-label';
@@ -71,6 +79,18 @@ var XraiHider = (function () {
         element.appendChild(label);
         element._xraiBlurLabel = label;
       }
+
+      // Guard: swallow clicks on the blurred article so X's link handlers don't
+      // navigate away when the user misses the peek button.
+      var guard = function (e) {
+        if (element.hasAttribute('data-xrai-revealed')) return;
+        var t = e.target;
+        if (t && (t.closest('.xrai-peek-btn') || t.closest('.xrai-blur-label'))) return;
+        e.preventDefault();
+        e.stopPropagation();
+      };
+      element.addEventListener('click', guard, true);
+      element._xraiBlurGuard = guard;
     }
   }
 
@@ -100,6 +120,10 @@ var XraiHider = (function () {
     if (element._xraiBlurLabel) {
       element._xraiBlurLabel.remove();
       delete element._xraiBlurLabel;
+    }
+    if (element._xraiBlurGuard) {
+      element.removeEventListener('click', element._xraiBlurGuard, true);
+      delete element._xraiBlurGuard;
     }
   }
 

--- a/extension/content/indicator.js
+++ b/extension/content/indicator.js
@@ -3,6 +3,10 @@ var XraiIndicator = (function () {
   'use strict';
 
   var pill = null;
+  var countsEl = null;
+  var statusEl = null;
+  var dotEl = null;
+  var gearEl = null;
   var popup = null;
   var counts = { shown: 0, hidden: 0 };
   var status = { connected: false, classify: false, reply: false, label: 'offline' };
@@ -12,40 +16,69 @@ var XraiIndicator = (function () {
     if (pill) return;
     pill = document.createElement('div');
     pill.id = 'xrai-pill';
-    pill.innerHTML = buildPillHtml();
-    document.body.appendChild(pill);
 
-    pill.querySelector('.xrai-pill-gear').addEventListener('click', function (e) {
+    countsEl = document.createElement('span');
+    countsEl.className = 'xrai-pill-text';
+
+    dotEl = document.createElement('span');
+    dotEl.className = 'xrai-dot xrai-dot-red';
+
+    statusEl = document.createElement('span');
+    statusEl.className = 'xrai-pill-status';
+
+    gearEl = document.createElement('span');
+    gearEl.className = 'xrai-pill-gear';
+    gearEl.textContent = '\u2699';
+    gearEl.addEventListener('click', function (e) {
       e.stopPropagation();
       togglePopup();
     });
-  }
 
-  function buildPillHtml() {
-    var dotClass = 'xrai-dot-red';
-    if (status.connected && status.classify) dotClass = 'xrai-dot-green';
-    else if (status.connected) dotClass = 'xrai-dot-orange';
+    pill.appendChild(countsEl);
+    pill.appendChild(document.createTextNode(' '));
+    pill.appendChild(dotEl);
+    pill.appendChild(statusEl);
+    pill.appendChild(document.createTextNode(' '));
+    pill.appendChild(gearEl);
 
-    var statusParts = [];
-    if (!status.connected) {
-      statusParts.push('ollama offline');
-    } else if (!status.classify) {
-      statusParts.push('ollama up · classify ✗ (CORS?)');
-    } else {
-      statusParts.push('local');
+    document.body.appendChild(pill);
+
+    // Hydrate counts from lifetime stats (fix #25)
+    if (typeof XraiMemory !== 'undefined' && XraiMemory.getStats) {
+      XraiMemory.getStats().then(function (stats) {
+        if (!stats) return;
+        counts.shown = stats.signal || 0;
+        counts.hidden = stats.noise || 0;
+        render();
+      });
     }
 
-    return '<span class="xrai-pill-text">xrai: ' +
-      counts.shown + ' shown | ' + counts.hidden + ' hidden</span>' +
-      ' <span class="xrai-dot ' + dotClass + '" title="server: ' + (status.connected ? '✓' : '✗') + ' classify: ' + (status.classify ? '✓' : '✗') + ' reply: ' + (status.reply ? '✓' : '✗') + '"></span>' +
-      '<span class="xrai-pill-status">' + statusParts.join('') + '</span>' +
-      ' <span class="xrai-pill-gear">&#x2699;</span>';
+    render();
+  }
+
+  function render() {
+    if (!pill) return;
+    countsEl.textContent = 'xrai: ' + counts.shown + ' shown | ' + counts.hidden + ' hidden';
+
+    var dotClass = 'xrai-dot xrai-dot-red';
+    if (status.connected && status.classify) dotClass = 'xrai-dot xrai-dot-green';
+    else if (status.connected) dotClass = 'xrai-dot xrai-dot-orange';
+    dotEl.className = dotClass;
+    dotEl.title = 'server: ' + (status.connected ? '\u2713' : '\u2717') +
+      ' classify: ' + (status.classify ? '\u2713' : '\u2717') +
+      ' reply: ' + (status.reply ? '\u2713' : '\u2717');
+
+    var statusText = '';
+    if (!status.connected) statusText = 'ollama offline';
+    else if (!status.classify) statusText = 'ollama up \u00b7 classify \u2717 (CORS?)';
+    else statusText = 'local';
+    statusEl.textContent = statusText;
   }
 
   function update(newCounts, newStatus) {
     if (newCounts) {
-      counts.shown = newCounts.shown || counts.shown;
-      counts.hidden = newCounts.hidden || counts.hidden;
+      if (typeof newCounts.shown === 'number') counts.shown = newCounts.shown;
+      if (typeof newCounts.hidden === 'number') counts.hidden = newCounts.hidden;
     }
     if (newStatus) {
       status.connected = newStatus.connected !== undefined ? newStatus.connected : status.connected;
@@ -53,18 +86,11 @@ var XraiIndicator = (function () {
       status.reply = newStatus.reply !== undefined ? newStatus.reply : status.reply;
       status.label = newStatus.label || status.label;
     }
-    if (pill) pill.innerHTML = buildPillHtml();
-    // Re-attach gear listener
-    if (pill) {
-      pill.querySelector('.xrai-pill-gear').addEventListener('click', function (e) {
-        e.stopPropagation();
-        togglePopup();
-      });
-    }
+    render();
   }
 
-  function incrementShown() { counts.shown++; update(); }
-  function incrementHidden() { counts.hidden++; update(); }
+  function incrementShown() { counts.shown++; render(); }
+  function incrementHidden() { counts.hidden++; render(); }
 
   function togglePopup() {
     if (popupOpen) { closePopup(); return; }
@@ -75,12 +101,10 @@ var XraiIndicator = (function () {
     popup.innerHTML = '<div class="xrai-settings-loading">Loading...</div>';
     document.body.appendChild(popup);
 
-    // Close on outside click
     setTimeout(function () {
       document.addEventListener('click', outsideClickHandler);
     }, 100);
 
-    // Load config and render
     XraiConfig.getConfig().then(function (cfg) {
       renderSettings(cfg);
     });
@@ -113,7 +137,6 @@ var XraiIndicator = (function () {
       '</div>' +
       '<div class="xrai-settings-stats" id="xrai-s-stats">Loading stats...</div>';
 
-    // Populate model dropdown from Ollama
     if (chrome.runtime && chrome.runtime.id) {
       chrome.runtime.sendMessage({ action: 'listModels' }, function (response) {
         if (chrome.runtime.lastError || !response) return;
@@ -130,14 +153,12 @@ var XraiIndicator = (function () {
       });
     }
 
-    // Threshold slider feedback
     var slider = popup.querySelector('#xrai-s-threshold');
     var sliderVal = popup.querySelector('#xrai-s-threshold-val');
     slider.addEventListener('input', function () {
       sliderVal.textContent = slider.value;
     });
 
-    // Save
     popup.querySelector('#xrai-s-save').addEventListener('click', function () {
       XraiConfig.saveConfig({
         model: popup.querySelector('#xrai-s-model').value,
@@ -149,7 +170,6 @@ var XraiIndicator = (function () {
       });
     });
 
-    // Clear memory
     popup.querySelector('#xrai-s-clear').addEventListener('click', function () {
       XraiMemory.clearAll().then(function () {
         var statsEl = popup.querySelector('#xrai-s-stats');
@@ -157,13 +177,12 @@ var XraiIndicator = (function () {
       });
     });
 
-    // Load stats and daily time
     Promise.all([XraiMemory.getStats(), XraiMemory.getDailyTime()]).then(function (results) {
       var stats = results[0];
       var dailySecs = results[1];
       var statsEl = popup.querySelector('#xrai-s-stats');
       if (!statsEl) return;
-      var timeSaved = Math.round(stats.noise * 3); // ~3s per hidden tweet
+      var timeSaved = Math.round(stats.noise * 3);
       var dailyMin = Math.floor(dailySecs / 60);
       var dailyLabel = dailyMin < 60
         ? dailyMin + 'm'

--- a/extension/content/reply.js
+++ b/extension/content/reply.js
@@ -8,23 +8,16 @@ var XraiReply = (function () {
   function attachReplyButton(element, data) {
     if (element.querySelector('.xrai-reply-btn')) return;
     var btn = document.createElement('div');
-    btn.className = 'xrai-reply-btn';
-    btn.innerHTML = '&#x1F4CB;'; // clipboard emoji
+    btn.className = 'xrai-reply-btn xrai-reply-btn-persistent';
+    btn.innerHTML = '&#x1F4CB;';
     btn.title = 'Generate reply';
     btn.addEventListener('click', function (e) {
       e.stopPropagation();
       e.preventDefault();
       showReplyCard(element, data);
     });
-    // Position relative to tweet actions area
-    var actions = element.querySelector('[role="group"]');
-    if (actions) {
-      actions.style.position = 'relative';
-      actions.appendChild(btn);
-    } else {
-      element.style.position = 'relative';
-      element.appendChild(btn);
-    }
+    element.style.position = 'relative';
+    element.appendChild(btn);
   }
 
   function showReplyCard(tweetEl, data) {

--- a/extension/content/styles.css
+++ b/extension/content/styles.css
@@ -139,24 +139,32 @@
   color: #888;
 }
 
-/* Reply button on signal tweets */
+/* Reply button on signal tweets — persistent, visible, easy to click */
 .xrai-reply-btn {
-  display: none;
   position: absolute;
-  right: -8px;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  font-size: 14px;
-  opacity: 0.5;
-  transition: opacity 0.15s;
+  font-size: 16px;
+  opacity: 0.85;
+  background: rgba(15, 15, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  backdrop-filter: blur(6px);
+  transition: opacity 0.15s, transform 0.15s, background 0.15s;
   z-index: 10;
+  user-select: none;
 }
-[role="group"]:hover .xrai-reply-btn,
-article:hover .xrai-reply-btn {
-  display: block;
+.xrai-reply-btn:hover {
+  opacity: 1;
+  transform: scale(1.08);
+  background: rgba(30, 30, 40, 0.95);
 }
-.xrai-reply-btn:hover { opacity: 1; }
 
 /* Reply card */
 .xrai-reply-card {
@@ -226,28 +234,32 @@ article:hover .xrai-reply-btn {
 }
 .xrai-reply-copy:hover { background: rgba(255, 255, 255, 0.2); }
 
-/* Peek button on blurred tweets */
+/* Peek button on blurred tweets — large, centered, high contrast */
 .xrai-peek-btn {
   position: absolute;
-  top: 8px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
-  z-index: 10;
-  background: rgba(15, 15, 20, 0.85);
-  color: #ccc;
+  transform: translate(-50%, -50%);
+  min-width: 100px;
+  min-height: 44px;
+  padding: 10px 20px;
+  z-index: 11;
+  background: rgba(15, 15, 20, 0.92);
+  color: #eee;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  font-size: 12px;
-  padding: 4px 10px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(8px);
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(10px);
   cursor: pointer;
   user-select: none;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.15s, transform 0.15s;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
 }
 .xrai-peek-btn:hover {
-  background: rgba(30, 30, 40, 0.95);
-  color: #fff;
+  background: rgba(40, 40, 55, 0.98);
+  transform: translate(-50%, -50%) scale(1.04);
 }
 
 /* Pending blur — applied immediately on detection, before classification */


### PR DESCRIPTION
## Summary

UX friction pass based on live QA session on x.com. Fixes five issues filed as #21-#25.

- **#21 Blur flash on signal tweets** — Added 300ms debounce to `blurPending` so tweets classified as signal before the delay never flash blur.
- **#22 Gear click race** — Stopped rewriting `pill.innerHTML` on every classification. Pill now uses stable DOM nodes (`countsEl`, `dotEl`, `statusEl`, `gearEl`) and updates `textContent`/`className` only, so the gear listener survives updates.
- **#23 Peek button mis-click navigates away** — Added a capture-phase click guard on blurred articles that swallows non-peek, non-label clicks so X's link handlers don't hijack the tap. Peek button also enlarged (min 100×44px, centered) for reliable touch.
- **#24 Reply button too small / hover-only** — Reply button now 32×32px circle, opacity 0.85 (always visible), and persistently attached to the article (no more `[role=group]` child placement that disappears on re-render).
- **#25 Counter resets to 0 on navigation** — `XraiIndicator.init()` now hydrates `counts.shown`/`counts.hidden` from `XraiMemory.getStats()` lifetime totals on startup.

## Why

From a live QA session driving Chrome against x.com with the extension loaded:

- Blur flash mean: 3.87s on signal tweets (felt jarring; classification almost always beats 300ms now).
- Gear click: unreliable via real mouse, worked via programmatic `.click()` → classic listener-loss race.
- Peek button: mis-click on a Bryan Johnson tweet navigated to `/bryan_johnson/status/...` and blew away feed position.
- Reply button: measured 14×21 effective hit box, only appeared on hover.
- Pill counter: reset to `0 shown | 0 hidden` on every SPA nav even though lifetime stats were intact in storage.

## Test plan

- [ ] Reload extension at `chrome://extensions` (content scripts cache until manual reload)
- [ ] Load x.com home feed — verify no blur flash on fast-classified signal tweets
- [ ] Click gear icon repeatedly — settings popup opens every time
- [ ] Click Peek button on a blurred tweet — reveals in place, no navigation
- [ ] Click anywhere else on a blurred tweet — no navigation
- [ ] Reply button visible without hover, 32×32px, click opens reply card
- [ ] Refresh home → counter shows lifetime totals, not 0

Closes #21
Closes #22
Closes #23
Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)